### PR TITLE
Add setuptools to the requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ opt-einsum==3.1.0
 protobuf==3.11.2
 PyYAML==5.3
 scipy==1.4.1
+setuptools==45.2.0
 six==1.14.0
 tensorboard==1.15.0
 tensorflow==1.15.0


### PR DESCRIPTION
Before that I got the error on macOS 10.15.3:
"tensorboard 1.15.0 has requirement setuptools>=41.0.0, but you'll have setuptools 40.8.0 which is incompatible."