### PR TITLE
added fix for nms bug

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -256,8 +256,8 @@ def get_yolo_boxes(model, images, net_h, net_w, anchors, obj_thresh, nms_thresh)
         correct_yolo_boxes(boxes, image_h, image_w, net_h, net_w)
 
         # suppress non-maximal boxes
-        do_nms(boxes, nms_thresh)        
-           
+        do_nms(boxes, nms_thresh)
+        boxes = remove_zeros_after_nms(boxes, obj_thresh)
         batch_boxes[i] = boxes
 
     return batch_boxes        
@@ -321,3 +321,16 @@ def _softmax(x, axis=-1):
     e_x = np.exp(x)
     
     return e_x / e_x.sum(axis, keepdims=True)
+
+def remove_zeros_after_nms(boxes, obj_thresh):
+    new_boxes = []
+    for box in boxes:
+        nb_class = len(box.classes)
+        has_confident = False
+        for cls in range(nb_class):
+            if box.classes[cls] > obj_thresh:
+                has_confident = True
+                break
+        if has_confident:
+            new_boxes.append(box)
+    return new_boxes


### PR DESCRIPTION
Hello Experiencor,
  Like all guys, I used your code to train a yolo model with my custom dataset. Your code worked well. I got the mAP value and I want to improve the mAP value. So I drew the pred_boxes around the object and I found a weird behaviour. I saw more than 1 bbox around each object. I was not sure at that time why it is printing like that. Then I added few codes to count true positive,true negative,false positive and all. I found that fp is so high. That is because the multiple bboxes around the same object. Later I found the issue. do_nms function nullify the surrounding bboxes with threshold. Nullify means just change the confidence to zero instead of removing it, this is correct if the bbox is associated with some other object also. But this method will fail, when the bbox is only associated with that particular class. do_nms nullify all the confidence value but the bbox will be still there which is wrong. So I wrote a simple fix for that. I also thought why mAP will still high. Later found that mAP value will not be affected by false positive. Thats why you got the results similar to the original yolo repo. I hope you understand the issue and fix done by me. If you like the work please merge this into master. And great thanks to you for spending your time in doing this cool stuffs which saves many people's time.