### PR TITLE
Update yolo3_one_file_to_detect_them_all.py

### DIFF
--- a/yolo3_one_file_to_detect_them_all.py
+++ b/yolo3_one_file_to_detect_them_all.py
@@ -1,5 +1,5 @@
 import argparse
-import os
+import os, sys
 import numpy as np
 from keras.layers import Conv2D, Input, BatchNormalization, LeakyReLU, ZeroPadding2D, UpSampling2D
 from keras.layers.merge import add, concatenate
@@ -7,7 +7,7 @@ from keras.models import Model
 import struct
 import cv2
 
-np.set_printoptions(threshold=np.nan)
+np.set_printoptions(threshold=sys.maxsize)
 os.environ["CUDA_DEVICE_ORDER"]="PCI_BUS_ID"
 os.environ["CUDA_VISIBLE_DEVICES"]="0"
 


### PR DESCRIPTION
cause of the line 10, error's happen

```python
Traceback (most recent call last):
  File "yolo3_one_file_to_detect_them_all.py", line 10, in <module>
    np.set_printoptions(threshold=np.nan)
  File "/home/syscon/.local/lib/python3.5/site-packages/numpy/core/arrayprint.py", line 259, in set_printoptions
    floatmode, legacy)
  File "/home/syscon/.local/lib/python3.5/site-packages/numpy/core/arrayprint.py", line 95, in _make_options_dict
    raise ValueError("threshold must be non-NAN, try "
ValueError: threshold must be non-NAN, try sys.maxsize for untruncated representation
```

code should be changed like this propose.