### PR TITLE
Fix: Image filename issue resolved

### DIFF
--- a/voc.py
+++ b/voc.py
@@ -24,7 +24,9 @@ def parse_voc_annotation(ann_dir, img_dir, cache_name, labels=[]):
             
             for elem in tree.iter():
                 if 'filename' in elem.tag:
-                    img['filename'] = img_dir + elem.text
+                    # split will just take image name 
+                    # to avoid full path annotation errors
+                    img['filename'] = img_dir + elem.text.split('/')[-1] 
                 if 'width' in elem.tag:
                     img['width'] = int(elem.text)
                 if 'height' in elem.tag:


### PR DESCRIPTION
annotation from CVAT tool gives full path including the image folder name too. In that case, the code crashes as no file is found at that path.
the split fix would just take the image name and append with path.